### PR TITLE
Enhance Chat Spam GUI

### DIFF
--- a/Bots/Chat Spam,.py
+++ b/Bots/Chat Spam,.py
@@ -33,8 +33,13 @@ def main():
         window_flags = PyImGui.WindowFlags.AlwaysAutoResize
         if PyImGui.begin("Chat Spam", window_flags):
             message_text = PyImGui.input_text("Message", message_text)
+            # Truncate message to 120 characters as Guild Wars chat has a
+            # maximum length of 120 characters.
+            if len(message_text) > 120:
+                message_text = message_text[:120]
             channel = PyImGui.input_text("Channel", channel)
-            running = ImGui.toggle_button("Start", running)
+            button_label = "Stop" if running else "Start"
+            running = ImGui.toggle_button(button_label, running)
         PyImGui.end()
     except Exception as e:
         Py4GW.Console.Log(MODULE_NAME, f"Error: {str(e)}", Py4GW.Console.MessageType.Error)


### PR DESCRIPTION
## Summary
- toggle chat spam button label between "Start" and "Stop"
- enforce Guild Wars chat message limit of 120 characters

## Testing
- `pyright`

------
https://chatgpt.com/codex/tasks/task_e_686c25e6dfc4833089fd08df94e6f1af